### PR TITLE
supports passed auth tokens

### DIFF
--- a/examples/mcp-servers.json
+++ b/examples/mcp-servers.json
@@ -17,5 +17,14 @@
     "tool_configuration": {
       "enabled": true
     }
+  },
+  {
+    "name": "figma",
+    "type": "url", 
+    "url": "https://figma.com/mcp/",
+    "authorization_token": "my-auth-token",
+    "tool_configuration": {
+      "enabled": true
+    }
   }
 ]

--- a/scripts/test-connections.js
+++ b/scripts/test-connections.js
@@ -34,7 +34,7 @@ async function main() {
       // Check authorization status
       if (server.authorization_token) {
         console.log(`   ✅ Has authorization token`);
-      } else if (await authManager.isAuthorized(server.name)) {
+      } else if (await authManager.isAuthorized(server)) {
         console.log(`   ✅ Has stored OAuth tokens`);
       } else {
         console.log(`   ⚠️  No authorization - OAuth flow required`);

--- a/specifications/passed-mcp-servers-authorization-token.md
+++ b/specifications/passed-mcp-servers-authorization-token.md
@@ -1,0 +1,18 @@
+Read:
+- `examples/mcp-servers.json`
+
+I'd like to make it so when an authorization_token is provided in an `mcp-servers` configuration, the
+`GET /api/connections` endpoint should return `"isAvailable": true,` for those connections.
+
+Similarly, if an environment variable like `MCP_${serverName}_authorization_token` is passed, then 
+`GET /api/connections` endpoint should return `"isAvailable": true,` for those connections.
+
+
+This seems like we will need to change `AuthManager`'s `isAuthorized` method. 
+
+Please think about different ways of doing this.  Lets make a minimal way. And lets make sure we can test this.
+
+One way might be to pass the mcpServers configuration to AuthManager so `isAuthorized` can use it.
+
+
+

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -13,7 +13,7 @@ export interface GetConnectionsDeps {
     getMcpServers: () => any[];
   };
   authManager: {
-    isAuthorized: (serverName: string) => Promise<boolean>;
+    isAuthorized: (mcpServer: any) => Promise<boolean>;
   };
 }
 
@@ -27,7 +27,8 @@ export function getConnections(deps: GetConnectionsDeps) {
 
       // Add MCP server connections
       for (const server of mcpServers) {
-        const isAvailable = await authManager.isAuthorized(server.name) || false;
+        // Pass the server configuration to isAuthorized
+        const isAvailable = await authManager.isAuthorized(server) || false;
         
         connections.push({
           name: server.name,
@@ -95,7 +96,7 @@ export interface AuthorizeMcpServerDeps {
     getMcpServers: () => any[];
   };
   authManager: {
-    isAuthorized: (serverName: string) => Promise<boolean>;
+    isAuthorized: (mcpServer: any) => Promise<boolean>;
     initiateAuthorization: (server: any) => Promise<string>;
   };
 }
@@ -117,7 +118,7 @@ export function authorizeMcpServer(deps: AuthorizeMcpServerDeps) {
         });
       }
 
-      if (await authManager.isAuthorized(mcpName)) {
+      if (await authManager.isAuthorized(server)) {
         return res.status(400).json({
           error: 'Bad Request',
           message: `MCP server '${mcpName}' is already authorized`,
@@ -154,7 +155,7 @@ export interface GetMcpServerStatusDeps {
     getMcpServers: () => any[];
   };
   authManager: {
-    isAuthorized: (serverName: string) => Promise<boolean>;
+    isAuthorized: (mcpServer: any) => Promise<boolean>;
     getTokens: (serverName: string) => any;
   };
 }
@@ -176,7 +177,7 @@ export function getMcpServerStatus(deps: GetMcpServerStatusDeps) {
         });
       }
 
-      const isAvailable = await authManager.isAuthorized(mcpName) || false;
+      const isAvailable = await authManager.isAuthorized(server) || false;
       const tokens = authManager.getTokens(mcpName);
 
       const response: ApiResponse = {

--- a/src/services/prompts.ts
+++ b/src/services/prompts.ts
@@ -17,7 +17,7 @@ export interface GetPromptsDeps {
     getMcpServers: () => any[];
   };
   authManager: {
-    isAuthorized: (serverName: string) => Promise<boolean>;
+    isAuthorized: (mcpServer: any) => Promise<boolean>;
   };
 }
 
@@ -36,7 +36,7 @@ export function getPrompts(deps: GetPromptsDeps) {
         if (prompt.mcp_servers) {
           for (const serverName of prompt.mcp_servers) {
             const server = mcpServers.find((s: any) => s.name === serverName);
-            const isAvailable = await authManager.isAuthorized(serverName) || false;
+            const isAvailable = server ? await authManager.isAuthorized(server) || false : false;
             
             connections.push({
               name: serverName,
@@ -105,7 +105,7 @@ export interface GetPromptDeps {
     getMcpServers: () => any[];
   };
   authManager: {
-    isAuthorized: (serverName: string) => Promise<boolean>;
+    isAuthorized: (mcpServer: any) => Promise<boolean>;
   };
 }
 
@@ -132,7 +132,7 @@ export function getPrompt(deps: GetPromptDeps) {
       if (prompt.mcp_servers) {
         for (const serverName of prompt.mcp_servers) {
           const server = mcpServers.find((s: any) => s.name === serverName);
-          const isAvailable = await authManager.isAuthorized(serverName) || false;
+          const isAvailable = server ? await authManager.isAuthorized(server) || false : false;
           
           connections.push({
             name: serverName,

--- a/tests/test-auth-manager-refresh.mjs
+++ b/tests/test-auth-manager-refresh.mjs
@@ -34,7 +34,8 @@ async function testRefreshTokenFunctionality() {
   
   // Test 3: Check authorization status
   console.log('📋 Test 3: Check authorization status');
-  const isAuthorized = await authManager.isAuthorized('jira');
+  const mockServer = { name: 'jira', type: 'url' }; // Minimal server config for test
+  const isAuthorized = await authManager.isAuthorized(mockServer);
   console.log('Is authorized:', isAuthorized);
   console.log('✅ Authorization check passed\n');
   
@@ -62,7 +63,8 @@ async function testRefreshTokenFunctionality() {
   authManager.storeTokens('jira-expired', expiredTokens);
   
   // This should return false and log refresh attempt (which will fail due to mock endpoint)
-  const isExpiredAuthorized = await authManager.isAuthorized('jira-expired');
+  const mockExpiredServer = { name: 'jira-expired', type: 'url' }; // Minimal server config for test
+  const isExpiredAuthorized = await authManager.isAuthorized(mockExpiredServer);
   console.log('Is expired token authorized:', isExpiredAuthorized);
   console.log('✅ Expired token handling test completed\n');
   

--- a/tests/test-authorization-token-support.js
+++ b/tests/test-authorization-token-support.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+ * Test authorization token support in AuthManager
+ * Tests both config-based authorization_token and environment variable MCP_${serverName}_authorization_token
+ */
+
+import { AuthManager } from '../src/auth/AuthManager.js';
+
+async function testAuthorizationTokenSupport() {
+  console.log('🧪 Testing Authorization Token Support in AuthManager\n');
+
+  const authManager = new AuthManager();
+
+  // Test 1: Config-based authorization_token
+  console.log('📋 Test 1: Config-based authorization_token');
+  const serverWithConfigToken = {
+    name: 'figma',
+    type: 'url',
+    url: 'https://figma.com/mcp/',
+    authorization_token: 'my-figma-auth-token',
+    tool_configuration: { enabled: true }
+  };
+
+  const isConfigAuthorized = await authManager.isAuthorized(serverWithConfigToken);
+  console.log('✅ Server with config authorization_token is authorized:', isConfigAuthorized);
+  console.assert(isConfigAuthorized === true, 'Config token should authorize the server');
+
+  // Test 2: Environment variable authorization_token
+  console.log('\n📋 Test 2: Environment variable authorization_token');
+  
+  // Set environment variable
+  process.env.MCP_github_authorization_token = 'my-github-env-token';
+  
+  const serverWithoutConfigToken = {
+    name: 'github',
+    type: 'url', 
+    url: 'https://api.githubcopilot.com/mcp/',
+    authorization_token: null,
+    tool_configuration: { enabled: true }
+  };
+
+  const isEnvAuthorized = await authManager.isAuthorized(serverWithoutConfigToken);
+  console.log('✅ Server with env authorization_token is authorized:', isEnvAuthorized);
+  console.assert(isEnvAuthorized === true, 'Environment token should authorize the server');
+
+  // Test 3: No authorization tokens (should fall back to OAuth check)
+  console.log('\n📋 Test 3: No authorization tokens (OAuth fallback)');
+  const serverWithoutTokens = {
+    name: 'jira',
+    type: 'url',
+    url: 'https://mcp.atlassian.com/v1/sse',
+    authorization_token: null,
+    tool_configuration: { enabled: true }
+  };
+
+  const isOAuthAuthorized = await authManager.isAuthorized(serverWithoutTokens);
+  console.log('✅ Server without tokens uses OAuth fallback:', isOAuthAuthorized);
+  // This should be false since we haven't stored any OAuth tokens
+
+  // Test 4: Priority test - config token should take precedence
+  console.log('\n📋 Test 4: Config token takes precedence over env token');
+  
+  // Set env token for test server
+  process.env.MCP_test_authorization_token = 'env-token';
+  
+  const serverWithBothTokens = {
+    name: 'test',
+    type: 'url',
+    authorization_token: 'config-token', // Config token present
+  };
+
+  const isPrecedenceAuthorized = await authManager.isAuthorized(serverWithBothTokens);
+  console.log('✅ Server with both tokens is authorized (config takes precedence):', isPrecedenceAuthorized);
+  console.assert(isPrecedenceAuthorized === true, 'Config token should take precedence');
+
+  // Test 5: Test with OAuth tokens stored (should still check authorization tokens first)
+  console.log('\n📋 Test 5: Authorization tokens take precedence over OAuth');
+  
+  // Store OAuth tokens for a server
+  authManager.storeTokens('oauth-test', {
+    access_token: 'oauth_access_token_123',
+    token_type: 'Bearer',
+    expires_at: Date.now() + 3600000 // Valid for 1 hour
+  });
+
+  const serverWithConfigAndOAuth = {
+    name: 'oauth-test',
+    type: 'url',
+    authorization_token: 'config-token-priority',
+  };
+
+  const isConfigPriorityAuthorized = await authManager.isAuthorized(serverWithConfigAndOAuth);
+  console.log('✅ Config token takes precedence over OAuth:', isConfigPriorityAuthorized);
+  console.assert(isConfigPriorityAuthorized === true, 'Config token should take precedence over OAuth');
+
+  // Clean up environment variables
+  delete process.env.MCP_github_authorization_token;
+  delete process.env.MCP_test_authorization_token;
+
+  console.log('\n🎉 All authorization token tests passed!');
+}
+
+// Run the test
+testAuthorizationTokenSupport().catch(error => {
+  console.error('❌ Test failed:', error);
+  process.exit(1);
+});

--- a/tests/test-connections-endpoint.js
+++ b/tests/test-connections-endpoint.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Test the /api/connections endpoint with authorization token support
+ */
+
+import fetch from 'node-fetch';
+
+async function testConnectionsEndpoint() {
+  console.log('🧪 Testing /api/connections endpoint with authorization token support\n');
+
+  const baseUrl = 'http://localhost:3000';
+  
+  try {
+    const response = await fetch(`${baseUrl}/api/connections`);
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    
+    console.log('✅ Response received:');
+    console.log(JSON.stringify(data, null, 2));
+    
+    // Check if connections exist
+    if (data.success && data.data && data.data.connections) {
+      console.log('\n📊 Connection Summary:');
+      
+      for (const connection of data.data.connections) {
+        const status = connection.isAvailable ? '✅ Available' : '❌ Not Available';
+        console.log(`  ${connection.name} (${connection.type}): ${status}`);
+        
+        if (connection.type === 'mcp-server') {
+          console.log(`    URL: ${connection.details?.url || 'N/A'}`);
+          if (connection.details?.lastAuthorized) {
+            console.log(`    Last Authorized: ${connection.details.lastAuthorized}`);
+          }
+        }
+      }
+      
+      // Look for servers that should be available due to authorization_token
+      const authorizedServers = data.data.connections.filter(c => 
+        c.type === 'mcp-server' && c.isAvailable
+      );
+      
+      if (authorizedServers.length > 0) {
+        console.log(`\n🔑 Found ${authorizedServers.length} authorized MCP server(s):`);
+        authorizedServers.forEach(server => {
+          console.log(`  - ${server.name}: ${server.description}`);
+        });
+      }
+      
+    } else {
+      console.log('⚠️  Unexpected response format');
+    }
+    
+  } catch (error) {
+    console.error('❌ Test failed:', error.message);
+    
+    if (error.message.includes('ECONNREFUSED')) {
+      console.log('\n💡 Tip: Make sure the development server is running on port 3000');
+      console.log('   Run: npm run dev');
+    }
+  }
+}
+
+// Run the test
+testConnectionsEndpoint();

--- a/tests/test-consolidated-auth-logic.js
+++ b/tests/test-consolidated-auth-logic.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Test the consolidated authorization token logic with ConfigManager
+ */
+
+import { AuthManager } from '../src/auth/AuthManager.js';
+import { ConfigManager } from '../src/config/ConfigManager.js';
+
+async function testConsolidatedAuthLogic() {
+  console.log('🧪 Testing Consolidated Authorization Token Logic\n');
+
+  const authManager = new AuthManager();
+  const configManager = new ConfigManager();
+
+  // Test 1: Environment variable gets picked up by ConfigManager
+  console.log('📋 Test 1: Environment variable integration with ConfigManager');
+  
+  // Set environment variable
+  process.env.MCP_github_authorization_token = 'env-github-token';
+  
+  // Mock an MCP server configuration (simulate what would be loaded from config)
+  configManager.mcpServers.set('github', {
+    name: 'github',
+    type: 'url',
+    url: 'https://api.github.com',
+    authorization_token: null // No config token
+  });
+
+  // Get server through ConfigManager (should include env token)
+  const githubServer = configManager.getMcpServer('github');
+  console.log('Server from ConfigManager:', {
+    name: githubServer.name,
+    hasAuthToken: !!githubServer.authorization_token,
+    authToken: githubServer.authorization_token?.substring(0, 10) + '...'
+  });
+
+  const isAuthorized = await authManager.isAuthorized(githubServer);
+  console.log('✅ GitHub server authorized via env token:', isAuthorized);
+  console.assert(isAuthorized === true, 'Should be authorized via environment token');
+
+  // Test 2: Config token takes precedence
+  console.log('\n📋 Test 2: Config token precedence');
+  
+  process.env.MCP_figma_authorization_token = 'env-figma-token';
+  
+  configManager.mcpServers.set('figma', {
+    name: 'figma',
+    type: 'url',
+    url: 'https://figma.com/mcp/',
+    authorization_token: 'config-figma-token' // Config token present
+  });
+
+  const figmaServer = configManager.getMcpServer('figma');
+  console.log('Figma server token (should be config, not env):', figmaServer.authorization_token);
+  console.assert(figmaServer.authorization_token === 'config-figma-token', 'Config token should take precedence');
+
+  const isFigmaAuthorized = await authManager.isAuthorized(figmaServer);
+  console.log('✅ Figma server authorized via config token:', isFigmaAuthorized);
+
+  // Test 3: Server without any tokens (OAuth fallback)
+  console.log('\n📋 Test 3: OAuth fallback');
+  
+  configManager.mcpServers.set('jira', {
+    name: 'jira',
+    type: 'url',
+    url: 'https://mcp.atlassian.com/v1/sse',
+    authorization_token: null
+  });
+
+  const jiraServer = configManager.getMcpServer('jira');
+  console.log('Jira server has auth token:', !!jiraServer.authorization_token);
+  
+  const isJiraAuthorized = await authManager.isAuthorized(jiraServer);
+  console.log('✅ Jira server authorized (should be false, no tokens):', isJiraAuthorized);
+  console.assert(isJiraAuthorized === false, 'Should not be authorized without tokens');
+
+  // Test 4: getMcpServers() also enriches tokens
+  console.log('\n📋 Test 4: getMcpServers() enrichment');
+  
+  const allServers = configManager.getMcpServers();
+  const githubFromList = allServers.find(s => s.name === 'github');
+  const figmaFromList = allServers.find(s => s.name === 'figma');
+  const jiraFromList = allServers.find(s => s.name === 'jira');
+
+  console.log('GitHub from list has auth token:', !!githubFromList.authorization_token);
+  console.log('Figma from list has auth token:', !!figmaFromList.authorization_token);
+  console.log('Jira from list has auth token:', !!jiraFromList.authorization_token);
+
+  console.assert(githubFromList.authorization_token === 'env-github-token', 'GitHub should have env token');
+  console.assert(figmaFromList.authorization_token === 'config-figma-token', 'Figma should have config token');
+  console.assert(!jiraFromList.authorization_token, 'Jira should have no token');
+
+  // Cleanup
+  delete process.env.MCP_github_authorization_token;
+  delete process.env.MCP_figma_authorization_token;
+
+  console.log('\n🎉 All consolidated authorization logic tests passed!');
+  console.log('\n💡 Benefits of consolidation:');
+  console.log('   - Environment variables are handled in one place (ConfigManager)');
+  console.log('   - AuthManager.isAuthorized() is simplified');
+  console.log('   - Consistent behavior across all parts of the system');
+  console.log('   - No duplicate environment variable checking');
+}
+
+// Run the test
+testConsolidatedAuthLogic().catch(error => {
+  console.error('❌ Test failed:', error);
+  process.exit(1);
+});

--- a/tests/test-duplicate-refresh-prevention.js
+++ b/tests/test-duplicate-refresh-prevention.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Test duplicate refresh prevention in AuthManager
+ */
+
+import { AuthManager } from '../src/auth/AuthManager.js';
+
+async function testDuplicateRefreshPrevention() {
+  console.log('🧪 Testing Duplicate Refresh Prevention\n');
+
+  const authManager = new AuthManager();
+
+  // Store expired tokens to trigger refresh
+  const expiredTokens = {
+    access_token: 'expired_access_token_123',
+    refresh_token: 'refresh_token_456', 
+    token_type: 'Bearer',
+    expires_in: -1, // Negative expires_in to ensure expiration
+    scope: 'read:jira-work',
+    // OAuth metadata for refresh (mock endpoints that will fail)
+    token_endpoint: 'https://httpbin.org/status/500', // This will fail, but that's okay for testing
+    client_id: 'mock_client_id',
+    issued_at: Date.now(),
+    expires_at: Date.now() - 1000, // Force expiration
+  };
+
+  authManager.storeTokens('test-service', expiredTokens);
+  console.log('✅ Stored expired tokens for test-service');
+
+  const mockServer = { 
+    name: 'test-service', 
+    type: 'url',
+    authorization_token: null 
+  };
+
+  console.log('\n📋 Test: Concurrent authorization checks');
+  console.log('Starting 5 concurrent isAuthorized() calls...');
+
+  // Start multiple concurrent authorization checks
+  const promises = [];
+  for (let i = 0; i < 5; i++) {
+    promises.push(
+      authManager.isAuthorized(mockServer).catch(error => {
+        console.log(`Call ${i + 1} failed (expected):`, error.message.substring(0, 50) + '...');
+        return false;
+      })
+    );
+  }
+
+  // Wait for all to complete
+  const results = await Promise.all(promises);
+  console.log('✅ All concurrent calls completed');
+  console.log('Results:', results);
+
+  console.log('\n💡 Expected behavior:');
+  console.log('- First call detects expired token and starts refresh');
+  console.log('- Subsequent calls wait for the first refresh to complete');
+  console.log('- Only one actual refresh request is made to the token endpoint');
+  console.log('- All calls get the same result');
+
+  console.log('\n🎉 Duplicate refresh prevention test completed!');
+  console.log('Check the logs above to verify only one refresh attempt was made.');
+}
+
+// Run the test
+testDuplicateRefreshPrevention().catch(error => {
+  console.error('❌ Test failed:', error);
+  process.exit(1);
+});

--- a/tests/test-prompt-mcp-pipeline.js
+++ b/tests/test-prompt-mcp-pipeline.js
@@ -78,7 +78,8 @@ async function testPromptMcpPipeline() {
     });
 
     console.log(`   ✅ Loaded ${configManager.getMcpServers().length} MCP servers from config`);
-    const isJiraAuthorized = await authManager.isAuthorized('jira-mcp');
+    const jiraMcpServer = configManager.getMcpServer('jira-mcp') || { name: 'jira-mcp', type: 'url' };
+    const isJiraAuthorized = await authManager.isAuthorized(jiraMcpServer);
     console.log(`   ✅ jira-mcp OAuth token stored: ${isJiraAuthorized}`);
 
     // 5. Test ConfigManager.prepareMcpServersForClaude()
@@ -131,7 +132,7 @@ async function testPromptMcpPipeline() {
       const hasConfigToken = server?.authorization_token;
       const envTokenKey = `MCP_${serverName}_authorization_token`;
       const hasEnvToken = process.env[envTokenKey];
-      const hasOAuthToken = await authManager.isAuthorized(serverName);
+      const hasOAuthToken = await authManager.isAuthorized(server || { name: serverName, type: 'url' });
       
       console.log(`   ${serverName}:`);
       console.log(`     📋 Config token: ${hasConfigToken ? 'Yes' : 'No'}`);

--- a/tests/verify-oauth-fix.js
+++ b/tests/verify-oauth-fix.js
@@ -40,7 +40,8 @@ console.log('✅ The Atlassian MCP OAuth flow is now fixed and working!');
   const authManager = new AuthManager();
   console.log('');
   console.log('🔍 Checking if jira service has valid tokens...');
-  const isAuthorized = await authManager.isAuthorized('jira');
+  const mockJiraServer = { name: 'jira', type: 'url' }; // Minimal server config for test
+  const isAuthorized = await authManager.isAuthorized(mockJiraServer);
   if (isAuthorized) {
     console.log('✅ Jira service is authorized');
     const tokens = authManager.getTokens('jira');


### PR DESCRIPTION
When an authorization_token is provided in an `mcp-servers` configuration, the
`GET /api/connections` endpoint should return `"isAvailable": true,` for those connections.

Similarly, if an environment variable like `MCP_${serverName}_authorization_token` is passed, then 
`GET /api/connections` endpoint should return `"isAvailable": true,` for those connections.