### PR TITLE
(standardize) Adding dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,12 @@
 {
   "name": "AI Coding Agent (Node)",
-  "build": {
-    "context": "..",
-    "dockerfile": "../Dockerfile"
-  },
+  "dockerComposeFile": "docker-compose.devcontainer.yml",
+  "service": "app",
+  "workspaceFolder": "/app",
+
+  "overrideCommand": true,
+  "shutdownAction": "stopCompose",
+  "runServices": ["app", "ngrok"],
 
   "updateRemoteUserUID": true,
 
@@ -14,18 +17,12 @@
         "esbenp.prettier-vscode",
         "ms-azuretools.vscode-docker"
       ],
-      "settings": {
-        "editor.formatOnSave": true
-      }
-    },
-    "settings": {
-      "editor.formatOnSave": true
+      "settings": { "editor.formatOnSave": true }
     }
   },
 
-  "forwardPorts": [3000],
+  "forwardPorts": [3000, 4040],
   "otherPortsAttributes": { "onAutoForward": "notify" },
-  "overrideCommand": true,
-  "runArgs": ["--entrypoint", "/bin/sh"],
+
   "postStartCommand": "npm start"
 }

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,20 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    # No ports needed; VS Code will forward 3000 for you
+
+  ngrok:
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    env_file:
+      - ./ngrok.env
+    command: >
+      http app:3000
+      --log=stdout
+      --log-format=json
+      --inspect=true
+    depends_on:
+      - app
+    network_mode: "service:app"

--- a/.devcontainer/ngrok.env.example
+++ b/.devcontainer/ngrok.env.example
@@ -1,0 +1,1 @@
+NGROK_AUTHTOKEN=your-token-here

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,11 +4,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Environment files
-.env
-.env.local
-.env.*.local
-
 # IDE files
 .vscode/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.local
 .env.production
 .env.staging
+ngrok.env
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -323,6 +323,15 @@ Or use the Visual Studio Dev Container to start the production server:
 
 This will build the Dockerfile image, start the frontend and backend applications and handle port forwarding. Consider this a local proudction server for testing purposes. Changes to source made in the devcontainer are propogated to your local source.
 
+#### Ngrok + devcontainer
+If you want to start the Ngrok service from within the dev container:
+```bash
+cp .devcontainer/ngrok.env.example .devcontainer/ngrok.env
+# update the NGROK_AUTHTOKEN value
+```
+Once the devcontainer comes up you can navigate to localhost:4040 and retrieve the tunnel URL.
+
+
 ### 3. Using the Web Dashboard
 
 Navigate to `http://localhost:3000` to access the dashboard where you can:


### PR DESCRIPTION
Adding [.devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) to standardize local development based on container image. 

Adding to documentation to ensure easier quickstart/usage for non-node developers + adding devcontainer mention